### PR TITLE
Enhance login flow and add cart reservation UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -96,6 +96,7 @@ button:disabled{ opacity:.6; cursor:default; }
 }
 .status.error .dot{ background:#fdecec; }
 .status.warn  .dot{ background:#fff7e6; }
+.status.error{ color:#fff; }
 
 /* Karten/Boxen */
 .card{
@@ -207,4 +208,24 @@ input, input::placeholder { color:#000 !important; }
   color:var(--muted);
   text-decoration:none;
 }
+
+/* Scrollbare Ergebnisliste */
+.scroll-list{
+  max-height:180px;
+  overflow-y:auto;
+  border:1px solid var(--border);
+  border-radius:8px;
+  padding:4px;
+  margin-top:6px;
+}
+.list-item{
+  display:flex;
+  gap:6px;
+  align-items:center;
+  font-size:.95rem;
+  padding:4px 0;
+}
+.list-item span{ flex:1; }
+.list-item.header{ font-weight:600; border-bottom:1px solid var(--border); padding-bottom:4px; margin-bottom:4px; }
+.summary{ font-weight:600; margin-top:8px; }
 

--- a/popup.html
+++ b/popup.html
@@ -7,21 +7,22 @@
 </head>
 <body>
   <main>
-    <h2>Login</h2>
+    <h2 id="loginTitle">Login</h2>
 
-    <div class="card">
+    <div id="loginCard" class="card">
       <input id="email" type="email" placeholder="E‑Mail" />
       <input id="password" type="password" placeholder="Passwort" />
       <button id="loginBtn">Anmelden</button>
 
       <!-- Status bleibt #status (wird von JS beschrieben) -->
       <div id="status" class="status"><span class="dot"></span><span>Nicht angemeldet</span></div>
-      <a id="logout" href="#" class="logout hidden">Logout</a>
     </div>
 
     <h2 class="section-title">Ergebnisse</h2>
     <!-- Ergebnisse: dein JS schreibt hier rein -->
     <div id="results" class="result-list"></div>
+
+    <a id="logout" href="#" class="logout hidden">Logout</a>
   </main>
 
   <script src="popup.js"></script>


### PR DESCRIPTION
## Summary
- Hide login form after successful authentication while keeping logout link accessible
- Display cart items in a scrollable, selectable list with "Reservieren" action
- Simplify status messages and show login errors in white without icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36b00d46c8330a4b544ab5e39ce5d