### PR TITLE
Ensure SCT cart items removed via delete button

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -155,7 +155,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const inStock = hits.filter(h => Number(h.menge) > 0).length;
     const rows = hits.map((h, i) => `
       <label class="result item-row">
-        <input type="checkbox" class="item-check" data-index="${i}" />
+        <input type="checkbox" class="item-check" data-index="${i}" ${Number(h.menge) > 0 ? "checked" : ""} />
         <div class="info">
           <div class="title">${esc(h.quelle || h.hersteller || "")}</div>
           <div class="title">${esc(h.name) ?? "(ohne Name)"}</div>


### PR DESCRIPTION
## Summary
- Default-check cart items that are in stock in popup UI
- Improve cart item removal using SCT delete button or quantity update with fallback

## Testing
- `node --check popup.js`
- `node --check content.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a376daee9483308fd2d1a3814851f8