### PR TITLE
feat: reserve items and clean cart

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,10 +11,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-    "host_permissions": [
-    "http://localhost:8000/*",
-    "https://lager-9ree.onrender.com/*"
-  ],
+  "host_permissions": ["<all_urls>"],
 
   "content_scripts": [
     {

--- a/popup.css
+++ b/popup.css
@@ -128,6 +128,8 @@ button:disabled{ opacity:.6; cursor:default; }
 .result .title + .title{ margin-top:2px; }
 .result .meta{ font-size:.9rem; color:var(--muted); }
 
+.item-row input[type=number]{ width:60px; margin-left:auto; }
+
 /* Nicht gefunden Liste */
 ul.plain{
   list-style:disc inside;
@@ -162,6 +164,9 @@ ul.plain{
 
 /* Utilities */
 .hidden{ display:none !important; }
+
+.settings{ position:absolute; top:8px; right:8px; background:none; border:none; cursor:pointer; width:auto; padding:4px; }
+#settingsPanel{ display:flex; flex-direction:column; gap:4px; }
 
 /* Tabellen (falls benötigt im Popup) */
 table{

--- a/popup.html
+++ b/popup.html
@@ -7,6 +7,12 @@
 </head>
 <body>
   <main>
+    <button id="settingsBtn" class="settings">⚙️</button>
+    <div id="settingsPanel" class="card hidden">
+      <input id="backendUrl" type="text" placeholder="Backend Base URL" />
+      <input id="jwtToken" type="text" placeholder="JWT Token" />
+      <button id="saveSettings" class="btn-ghost">Speichern</button>
+    </div>
     <h2 id="loginTitle">Login</h2>
 
     <div id="loginCard" class="card">

--- a/popup.js
+++ b/popup.js
@@ -4,11 +4,18 @@ document.addEventListener("DOMContentLoaded", () => {
   const logoutEl = document.getElementById("logout");
   const loginCard = document.getElementById("loginCard");
   const loginTitle = document.getElementById("loginTitle");
+  const settingsBtn = document.getElementById("settingsBtn");
+  const settingsPanel = document.getElementById("settingsPanel");
+  const backendInput = document.getElementById("backendUrl");
+  const tokenInput = document.getElementById("jwtToken");
+  const saveSettingsBtn = document.getElementById("saveSettings");
   let currentData = null;
 
   // ---- Konfiguration ----
   const DEFAULT_API_BASE = "https://lager-9ree.onrender.com";
   let API_BASE = DEFAULT_API_BASE;
+  let BACKEND_BASE_URL = "";
+  let JWT_TOKEN = "";
 
   const storageGet = (area, key) =>
     new Promise(resolve => chrome.storage[area].get(key, v => resolve(v || {})));
@@ -23,9 +30,27 @@ document.addEventListener("DOMContentLoaded", () => {
     if (statusEl) statusEl.textContent = `API: ${API_BASE}`;
   }
 
+  async function loadSettings() {
+    const { backendUrl, jwtToken } = await storageGet("sync", ["backendUrl", "jwtToken"]);
+    BACKEND_BASE_URL = backendUrl || localStorage.getItem("backendUrl") || "";
+    JWT_TOKEN = jwtToken || localStorage.getItem("jwtToken") || "";
+    if (backendInput) backendInput.value = BACKEND_BASE_URL;
+    if (tokenInput) tokenInput.value = JWT_TOKEN;
+  }
+
+  async function saveSettings() {
+    BACKEND_BASE_URL = backendInput.value.trim();
+    JWT_TOKEN = tokenInput.value.trim();
+    await storageSet("sync", { backendUrl: BACKEND_BASE_URL, jwtToken: JWT_TOKEN });
+    localStorage.setItem("backendUrl", BACKEND_BASE_URL);
+    localStorage.setItem("jwtToken", JWT_TOKEN);
+    settingsPanel?.classList.add("hidden");
+  }
+
   // Initialisierung: API-Basis setzen, Login-Status prüfen und Warenkorb anfragen
   (async function init() {
     try {
+      await loadSettings();
       await initApiBase();
       await restoreLogin();
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -37,6 +62,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("loginBtn").addEventListener("click", onLogin);
   logoutEl?.addEventListener("click", onLogout);
+  settingsBtn?.addEventListener("click", () => settingsPanel?.classList.toggle("hidden"));
+  saveSettingsBtn?.addEventListener("click", saveSettings);
 
   async function onLogin() {
     const email = document.getElementById("email").value;
@@ -161,29 +188,85 @@ document.addEventListener("DOMContentLoaded", () => {
           <div class="title">${esc(h.name) ?? "(ohne Name)"}</div>
           <div class="meta">${esc(h.artikelnummer) ?? "—"} · ${h.menge ?? "—"}</div>
         </div>
+        <input type="number" class="item-qty" min="1" max="${h.menge || 1}" value="1" />
       </label>
     `).join("");
     resultsEl.innerHTML = `
       <div class="summary">${total} Artikel im Warenkorb, davon ${inStock} im Lager</div>
       <div class="scroll-list">${rows || "<div>Keine Treffer</div>"}</div>
+      <label class="row"><input type="checkbox" id="reloadAfter" checked /> Nach Entfernen Seite neu laden</label>
       <button id="reserveBtn">Reservieren</button>
     `;
     const itemChecks = Array.from(resultsEl.querySelectorAll(".item-check"));
+    const qtyInputs = Array.from(resultsEl.querySelectorAll(".item-qty"));
+    const reloadChk = document.getElementById("reloadAfter");
     document.getElementById("reserveBtn")?.addEventListener("click", async () => {
-      const selectedSkus = hits
-        .filter((_, idx) => itemChecks[idx]?.checked)
-        .map(h => h.artikelnummer)
-        .filter(Boolean);
-      const remaining = hits.filter((_, idx) => !itemChecks[idx]?.checked);
-      currentData.hits = remaining;
-      renderResults(currentData);
+      const selected = hits
+        .map((h, idx) => ({ sku: h.artikelnummer, qty: Number(qtyInputs[idx]?.value) || 1, checked: itemChecks[idx]?.checked }))
+        .filter(x => x.checked && x.sku);
+      if (!selected.length) return;
+      const payload = {
+        name: `Reservierung ${new Date().toISOString().slice(0,16)}`,
+        items: selected.map(x => ({ artikelnummer: x.sku, menge: x.qty })),
+        hinweis: "von Browser-Extension"
+      };
+      const reserveBtn = document.getElementById("reserveBtn");
+      reserveBtn.disabled = true;
+      if (statusEl) {
+        statusEl.textContent = "Reserviere...";
+        statusEl.classList.remove("error", "success");
+      }
       try {
-        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-        if (tab?.id && selectedSkus.length) {
-          chrome.tabs.sendMessage(tab.id, { type: "REMOVE_CART_ITEMS", artikelnummern: selectedSkus });
+        const res = await fetch(`${BACKEND_BASE_URL}/reservieren`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${JWT_TOKEN}`
+          },
+          body: JSON.stringify(payload)
+        });
+        if (res.status === 401 || res.status === 403) {
+          if (statusEl) {
+            statusEl.textContent = "Bitte Token in den ⚙️-Einstellungen eintragen/erneuern";
+            statusEl.classList.add("error");
+          }
+          return;
+        }
+        if (!res.ok) throw new Error(await res.text());
+        const resp = await res.json();
+        const reserved = resp.reserved || [];
+        const notRes = resp.not_reserved || [];
+        if (statusEl) {
+          statusEl.textContent = `Reservierung #${resp.reservierung_id} angelegt (${reserved.length} reserviert, ${notRes.length} nicht)`;
+          statusEl.classList.add("success");
+        }
+        console.info("[RES] reserviert", reserved);
+        console.info("[RES] nicht reserviert", notRes);
+        if (reserved.length) {
+          const reservedSkus = reserved.map(r => r.artikelnummer);
+          currentData.hits = hits.filter(h => !reservedSkus.includes(h.artikelnummer));
+          renderResults(currentData);
+          try {
+            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+            chrome.tabs.sendMessage(tab.id, {
+              type: "REMOVE_CART_ITEMS",
+              items: reserved.map(r => ({ sku: r.artikelnummer, qty: r.menge })),
+              reload: reloadChk?.checked !== false
+            });
+          } catch (e) {
+            console.warn("[RES] REMOVE_CART_ITEMS Fehler", e);
+          }
+        } else {
+          console.warn("[RES] reserved leer");
         }
       } catch (e) {
-        console.warn("REMOVE_CART_ITEMS Fehler:", e);
+        console.warn("[RES] Fehler", e);
+        if (statusEl) {
+          statusEl.textContent = "Reservieren fehlgeschlagen";
+          statusEl.classList.add("error");
+        }
+      } finally {
+        reserveBtn.disabled = false;
       }
     });
   }


### PR DESCRIPTION
## Summary
- add configurable backend URL and JWT token settings
- send selected cart items to backend reservation endpoint and remove reserved items from shop
- improve content script deletion logic for SCT shop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e87102c8330a91f43f8d699aefb