### PR TITLE
feat: prompt name and backend check

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
       <input id="backendUrl" type="text" placeholder="Backend Base URL" />
       <input id="jwtToken" type="text" placeholder="JWT Token" />
       <button id="saveSettings" class="btn-ghost">Speichern</button>
+      <div id="backendStatus" class="status"></div>
     </div>
     <h2 id="loginTitle">Login</h2>
 


### PR DESCRIPTION
## Summary
- ask for a reservation name before submitting items
- show backend connectivity status and validate settings

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a397bc0928833094367156090a7a91