### PR TITLE
Simplify reservation popup and dark theme

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -2,14 +2,9 @@
 
 /* Base */
 :root{
-  --bg:#fff;
-  --fg:#111;
-  --muted:#666;
-  --primary:#007bff;
-  --primary-hover:#0056b3;
-  --border:#ccc;
-  --shadow:0 4px 16px rgba(0,0,0,.1);
-  --radius:10px;
+  --bg:#0f1115; --fg:#e9eaee; --muted:#a2a7b3;
+  --primary:#3b82f6; --primary-hover:#2563eb; --border:#2a2f3a;
+  --shadow:0 6px 20px rgba(0,0,0,.45); --radius:10px;
 }
 
 html,body{
@@ -52,9 +47,12 @@ select{
   border-radius:6px;
   border:1px solid var(--border);
   font-size:1rem;
-  background:#fff;
+  background:#151922;
+  color:#fff;
   appearance:none;
 }
+
+input::placeholder{ color:#c9ceda; }
 
 /* Button */
 button{
@@ -100,7 +98,7 @@ button:disabled{ opacity:.6; cursor:default; }
 
 /* Karten/Boxen */
 .card{
-  background:#fff;
+  background:#151922;
   border-radius:var(--radius);
   padding:16px;
   margin:10px 0;
@@ -118,7 +116,7 @@ button:disabled{ opacity:.6; cursor:default; }
   border:1px solid var(--border);
   border-radius:8px;
   padding:12px;
-  background:#fff;
+  background:#151922;
   display:flex;
   gap:8px;
   align-items:flex-start;
@@ -147,10 +145,14 @@ ul.plain{
 }
 
 /* Kompakte Zeilenlayouts */
-.row{
-  display:flex; gap:8px; align-items:center;
+
+/* "Alle auswählen" Zeile */
+.select-all{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin-top:8px;
 }
-.row > *{ flex:1; }
 
 /* Hamburger/Topbar (falls du sie ins Popup nimmst) */
 .topbar{
@@ -163,10 +165,8 @@ ul.plain{
 .hamburger div{ height:3px; background:#333; border-radius:2px; }
 
 /* Utilities */
+.field-error{ color:#ffb4b4; font-size:.9rem; margin-top:4px; }
 .hidden{ display:none !important; }
-
-.settings{ position:absolute; top:8px; right:8px; background:none; border:none; cursor:pointer; width:auto; padding:4px; }
-#settingsPanel{ display:flex; flex-direction:column; gap:4px; }
 
 /* Tabellen (falls benötigt im Popup) */
 table{
@@ -185,22 +185,6 @@ table button, table a{
   body{ width:420px; }
   button{ font-size:1.05rem; padding:16px; }
 }
-
-/* Optional: Dark Mode an OS koppeln */
-@media (prefers-color-scheme: dark){
-  :root{
-    --bg:#0f1115; --fg:#e9eaee; --muted:#a2a7b3;
-    --primary:#3b82f6; --primary-hover:#2563eb; --border:#2a2f3a;
-    --shadow:0 6px 20px rgba(0,0,0,.45);
-  }
-  body, main, .card, .result, input, textarea, select{ background:#151922; color:var(--fg); }
-  input, textarea, select, .result{ border-color:var(--border); }
-  .hamburger div{ background:#e9eaee; }
-}
-
-/* Schriftfarbe beim Login immer schwarz */
-body, .status { color:#000 !important; }
-input, input::placeholder { color:#000 !important; }
 
 /* Logout-Link unten klein */
 .logout {

--- a/popup.html
+++ b/popup.html
@@ -2,18 +2,12 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Lager Login</title>
+  <title>ShelfMate</title>
   <link rel="stylesheet" href="popup.css" />
 </head>
 <body>
+  <div class="topbar"><span class="app-name">ShelfMate</span></div>
   <main>
-    <button id="settingsBtn" class="settings">⚙️</button>
-    <div id="settingsPanel" class="card hidden">
-      <input id="backendUrl" type="text" placeholder="Backend Base URL" />
-      <input id="jwtToken" type="text" placeholder="JWT Token" />
-      <button id="saveSettings" class="btn-ghost">Speichern</button>
-      <div id="backendStatus" class="status"></div>
-    </div>
     <h2 id="loginTitle">Login</h2>
 
     <div id="loginCard" class="card">
@@ -25,9 +19,15 @@
       <div id="status" class="status"><span class="dot"></span><span>Nicht angemeldet</span></div>
     </div>
 
-    <h2 class="section-title">Ergebnisse</h2>
+    <h2 id="resultsTitle" class="section-title hidden">Ergebnisse</h2>
     <!-- Ergebnisse: dein JS schreibt hier rein -->
-    <div id="results" class="result-list"></div>
+    <div id="results" class="result-list hidden"></div>
+
+    <div id="reservationBox" class="card hidden">
+      <input id="reservationName" type="text" placeholder="Name der Reservierung" />
+      <div id="reservationError" class="field-error hidden">Bitte einen Namen eingeben.</div>
+      <button id="reserveBtn">Reservieren</button>
+    </div>
 
     <a id="logout" href="#" class="logout hidden">Logout</a>
   </main>

--- a/popup.js
+++ b/popup.js
@@ -4,19 +4,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const logoutEl = document.getElementById("logout");
   const loginCard = document.getElementById("loginCard");
   const loginTitle = document.getElementById("loginTitle");
-  const settingsBtn = document.getElementById("settingsBtn");
-  const settingsPanel = document.getElementById("settingsPanel");
-  const backendInput = document.getElementById("backendUrl");
-  const tokenInput = document.getElementById("jwtToken");
-  const saveSettingsBtn = document.getElementById("saveSettings");
-  const backendStatusEl = document.getElementById("backendStatus");
+  const reserveBtn = document.getElementById("reserveBtn");
+  const reservationBox = document.getElementById("reservationBox");
+  const resultsTitle = document.getElementById("resultsTitle");
   let currentData = null;
 
   // ---- Konfiguration ----
   const DEFAULT_API_BASE = "https://lager-9ree.onrender.com";
   let API_BASE = DEFAULT_API_BASE;
-  let BACKEND_BASE_URL = "";
-  let JWT_TOKEN = "";
 
   const storageGet = (area, key) =>
     new Promise(resolve => chrome.storage[area].get(key, v => resolve(v || {})));
@@ -31,54 +26,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (statusEl) statusEl.textContent = `API: ${API_BASE}`;
   }
 
-  async function loadSettings() {
-    const { backendUrl, jwtToken } = await storageGet("sync", ["backendUrl", "jwtToken"]);
-    BACKEND_BASE_URL = backendUrl || localStorage.getItem("backendUrl") || "";
-    JWT_TOKEN = jwtToken || localStorage.getItem("jwtToken") || "";
-    if (backendInput) backendInput.value = BACKEND_BASE_URL;
-    if (tokenInput) tokenInput.value = JWT_TOKEN;
-    await checkBackend();
-  }
-
-  async function saveSettings() {
-    BACKEND_BASE_URL = backendInput.value.trim();
-    JWT_TOKEN = tokenInput.value.trim();
-    await storageSet("sync", { backendUrl: BACKEND_BASE_URL, jwtToken: JWT_TOKEN });
-    localStorage.setItem("backendUrl", BACKEND_BASE_URL);
-    localStorage.setItem("jwtToken", JWT_TOKEN);
-    settingsPanel?.classList.add("hidden");
-    await checkBackend();
-  }
-
-  async function checkBackend() {
-    if (!BACKEND_BASE_URL) {
-      if (backendStatusEl) backendStatusEl.textContent = "";
-      return false;
-    }
-    try {
-      const res = await fetch(`${BACKEND_BASE_URL}/reservierungen`, {
-        method: "HEAD",
-        headers: JWT_TOKEN ? { Authorization: `Bearer ${JWT_TOKEN}` } : {}
-      });
-      const ok = res.ok || res.status === 401 || res.status === 403;
-      if (backendStatusEl) {
-        backendStatusEl.innerHTML = `<span class="dot"></span><span>${ok ? "Verbunden" : "Keine Verbindung"}</span>`;
-        backendStatusEl.classList.toggle("error", !ok);
-      }
-      return ok;
-    } catch (e) {
-      if (backendStatusEl) {
-        backendStatusEl.innerHTML = '<span class="dot"></span><span>Keine Verbindung</span>';
-        backendStatusEl.classList.add("error");
-      }
-      return false;
-    }
-  }
-
   // Initialisierung: API-Basis setzen, Login-Status prüfen und Warenkorb anfragen
   (async function init() {
     try {
-      await loadSettings();
       await initApiBase();
       await restoreLogin();
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -90,8 +40,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("loginBtn").addEventListener("click", onLogin);
   logoutEl?.addEventListener("click", onLogout);
-  settingsBtn?.addEventListener("click", () => settingsPanel?.classList.toggle("hidden"));
-  saveSettingsBtn?.addEventListener("click", saveSettings);
+  reserveBtn?.addEventListener("click", onReserve);
 
   async function onLogin() {
     const email = document.getElementById("email").value;
@@ -118,6 +67,15 @@ document.addEventListener("DOMContentLoaded", () => {
       loginCard?.classList.add("hidden");
       loginTitle?.classList.add("hidden");
       logoutEl?.classList.remove("hidden");
+      resultsTitle?.classList.remove("hidden");
+      resultsEl?.classList.remove("hidden");
+      reservationBox?.classList.remove("hidden");
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab?.id) await chrome.tabs.sendMessage(tab.id, { type: "REQUEST_CART" });
+      } catch (e) {
+        console.warn("REQUEST_CART nach Login nicht möglich:", e);
+      }
     } catch (e) {
       console.error(e);
       if (statusEl) {
@@ -133,6 +91,11 @@ document.addEventListener("DOMContentLoaded", () => {
     logoutEl?.classList.add("hidden");
     loginCard?.classList.remove("hidden");
     loginTitle?.classList.remove("hidden");
+    resultsTitle?.classList.add("hidden");
+    resultsEl?.classList.add("hidden");
+    reservationBox?.classList.add("hidden");
+    if (resultsEl) resultsEl.innerHTML = "";
+    currentData = null;
     if (statusEl) {
       statusEl.textContent = "";
       statusEl.classList.remove("error");
@@ -149,6 +112,9 @@ document.addEventListener("DOMContentLoaded", () => {
       loginCard?.classList.add("hidden");
       loginTitle?.classList.add("hidden");
       logoutEl?.classList.remove("hidden");
+      resultsTitle?.classList.remove("hidden");
+      resultsEl?.classList.remove("hidden");
+      reservationBox?.classList.remove("hidden");
     }
   }
 
@@ -222,89 +188,98 @@ document.addEventListener("DOMContentLoaded", () => {
     resultsEl.innerHTML = `
       <div class="summary">${total} Artikel im Warenkorb, davon ${inStock} im Lager</div>
       <div class="scroll-list">${rows || "<div>Keine Treffer</div>"}</div>
-      <label class="row"><input type="checkbox" id="reloadAfter" checked /> Nach Entfernen Seite neu laden</label>
-      <button id="reserveBtn">Reservieren</button>
+      <label class="select-all"><input type="checkbox" id="selectAll" /> Alle auswählen</label>
     `;
+    const selectAll = document.getElementById("selectAll");
+    if (selectAll) {
+      selectAll.addEventListener("change", () => {
+        const itemChecks = Array.from(resultsEl.querySelectorAll(".item-check"));
+        itemChecks.forEach(chk => { chk.checked = selectAll.checked; });
+      });
+    }
+  }
+
+  async function onReserve() {
+    const hits = currentData?.hits || [];
     const itemChecks = Array.from(resultsEl.querySelectorAll(".item-check"));
     const qtyInputs = Array.from(resultsEl.querySelectorAll(".item-qty"));
-    const reloadChk = document.getElementById("reloadAfter");
-    document.getElementById("reserveBtn")?.addEventListener("click", async () => {
-      const selected = hits
-        .map((h, idx) => ({ sku: h.artikelnummer, qty: Number(qtyInputs[idx]?.value) || 1, checked: itemChecks[idx]?.checked }))
-        .filter(x => x.checked && x.sku);
-      if (!selected.length) return;
-      const reserveBtn = document.getElementById("reserveBtn");
-      const name = prompt("Name der Reservierung:");
-      if (!name || !name.trim()) {
+    const selected = hits
+      .map((h, idx) => ({ sku: h.artikelnummer, qty: Number(qtyInputs[idx]?.value) || 1, checked: itemChecks[idx]?.checked }))
+      .filter(x => x.checked && x.sku);
+    if (!selected.length) return;
+
+    const nameInput = document.getElementById("reservationName");
+    const errEl = document.getElementById("reservationError");
+    const name = (nameInput?.value || "").trim();
+    if (!name) {
+      errEl?.classList.remove("hidden");
+      return;
+    } else {
+      errEl?.classList.add("hidden");
+    }
+
+    const payload = {
+      name,
+      items: selected.map(x => ({ artikelnummer: x.sku, menge: x.qty })),
+      hinweis: "von Browser-Extension",
+    };
+
+    if (reserveBtn) reserveBtn.disabled = true;
+    if (statusEl) {
+      statusEl.textContent = "Reserviere...";
+      statusEl.classList.remove("error", "success");
+    }
+    try {
+      const { token } = await storageGet("local", "token");
+      const res = await fetch(`${API_BASE}/reservierungen`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+      });
+      if (res.status === 401 || res.status === 403) {
         if (statusEl) {
-          statusEl.textContent = "Name erforderlich";
+          statusEl.textContent = "Bitte erneut einloggen.";
           statusEl.classList.add("error");
         }
         return;
       }
-      const payload = {
-        name: name.trim(),
-        items: selected.map(x => ({ artikelnummer: x.sku, menge: x.qty })),
-        hinweis: "von Browser-Extension"
-      };
-      reserveBtn.disabled = true;
+      if (!res.ok) throw new Error(await res.text());
+      const resp = await res.json();
+      const reserved = resp.reserved || [];
+      const notRes = resp.not_reserved || [];
       if (statusEl) {
-        statusEl.textContent = "Reserviere...";
-        statusEl.classList.remove("error", "success");
+        statusEl.textContent = `Reservierung #${resp.reservierung_id} angelegt (${reserved.length} reserviert, ${notRes.length} nicht)`;
+        statusEl.classList.add("success");
       }
-      try {
-        const res = await fetch(`${BACKEND_BASE_URL}/reservieren`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${JWT_TOKEN}`
-          },
-          body: JSON.stringify(payload)
-        });
-        if (res.status === 401 || res.status === 403) {
-          if (statusEl) {
-            statusEl.textContent = "Bitte Token in den ⚙️-Einstellungen eintragen/erneuern";
-            statusEl.classList.add("error");
-          }
-          return;
+      if (reserved.length) {
+        const reservedSkus = reserved.map(r => r.artikelnummer);
+        currentData.hits = hits.filter(h => !reservedSkus.includes(h.artikelnummer));
+        renderResults(currentData);
+        try {
+          const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+          chrome.tabs.sendMessage(tab.id, {
+            type: "REMOVE_CART_ITEMS",
+            items: reserved.map(r => ({ sku: r.artikelnummer, qty: r.menge })),
+            reload: true
+          });
+        } catch (e) {
+          console.warn("[RES] REMOVE_CART_ITEMS Fehler", e);
         }
-        if (!res.ok) throw new Error(await res.text());
-        const resp = await res.json();
-        const reserved = resp.reserved || [];
-        const notRes = resp.not_reserved || [];
-        if (statusEl) {
-          statusEl.textContent = `Reservierung #${resp.reservierung_id} angelegt (${reserved.length} reserviert, ${notRes.length} nicht)`;
-          statusEl.classList.add("success");
-        }
-        console.info("[RES] reserviert", reserved);
-        console.info("[RES] nicht reserviert", notRes);
-        if (reserved.length) {
-          const reservedSkus = reserved.map(r => r.artikelnummer);
-          currentData.hits = hits.filter(h => !reservedSkus.includes(h.artikelnummer));
-          renderResults(currentData);
-          try {
-            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-            chrome.tabs.sendMessage(tab.id, {
-              type: "REMOVE_CART_ITEMS",
-              items: reserved.map(r => ({ sku: r.artikelnummer, qty: r.menge })),
-              reload: reloadChk?.checked !== false
-            });
-          } catch (e) {
-            console.warn("[RES] REMOVE_CART_ITEMS Fehler", e);
-          }
-        } else {
-          console.warn("[RES] reserved leer");
-        }
-      } catch (e) {
-        console.warn("[RES] Fehler", e);
-        if (statusEl) {
-          statusEl.textContent = "Reservieren fehlgeschlagen";
-          statusEl.classList.add("error");
-        }
-      } finally {
-        reserveBtn.disabled = false;
+      } else {
+        console.warn("[RES] reserved leer");
       }
-    });
+    } catch (e) {
+      console.warn("[RES] Fehler", e);
+      if (statusEl) {
+        statusEl.textContent = "Reservieren fehlgeschlagen";
+        statusEl.classList.add("error");
+      }
+    } finally {
+      if (reserveBtn) reserveBtn.disabled = false;
+    }
   }
 
   function esc(s){ return s==null ? s : String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }


### PR DESCRIPTION
## Summary
- show ShelfMate branding and hide reservation UI until login
- remove reload toggle and streamline "Alle auswählen" layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9d76808483309b7dcb17e09dc8ca