### PR TITLE
Integrate fuzzy matching and cleanup UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -39,6 +39,7 @@ input[type="text"],
 input[type="email"],
 input[type="password"],
 input[type="search"],
+input[type="number"],
 textarea,
 select{
   width:100%;
@@ -127,6 +128,20 @@ button:disabled{ opacity:.6; cursor:default; }
 .result .meta{ font-size:.9rem; color:var(--muted); }
 
 .item-row input[type=number]{ width:60px; margin-left:auto; }
+
+.disabled{ opacity:.5; pointer-events:none; }
+
+.badge{
+  display:inline-block;
+  padding:2px 4px;
+  border-radius:4px;
+  font-size:.7rem;
+  margin-left:4px;
+  color:#fff;
+}
+.badge.safe{ background:#16a34a; }
+.badge.medium{ background:#ca8a04; }
+.badge.low{ background:#6b7280; }
 
 /* Nicht gefunden Liste */
 ul.plain{

--- a/popup.html
+++ b/popup.html
@@ -29,12 +29,6 @@
       <button id="reserveBtn">Reservieren</button>
     </div>
 
-    <div id="reservationBox" class="card">
-      <input id="reservationName" type="text" placeholder="Name der Reservierung" />
-      <div id="reservationError" class="field-error hidden">Bitte einen Namen eingeben.</div>
-      <button id="reserveBtn">Reservieren</button>
-    </div>
-
     <a id="logout" href="#" class="logout hidden">Logout</a>
   </main>
 


### PR DESCRIPTION
## Summary
- hide reservation name field until login and remove duplicate block
- show fuzzy score and reason, auto-select safe matches, disable low-confidence hits
- style disabled rows and add badges for match confidence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acab9ebcfc83309fc59936dab31d23